### PR TITLE
add bias, bias_corrected, and variance to bootstrap module

### DIFF
--- a/resample/bootstrap.py
+++ b/resample/bootstrap.py
@@ -225,12 +225,7 @@ def bias_corrected(fn: Callable, sample: Sequence, **kwargs) -> np.ndarray:
     ndarray
         Estimate with some bias removed.
     """
-
-    theta = fn(sample)
-    thetas = bootstrap(fn, sample, **kwargs)
-    # bias = mean(thetas) - theta
-    # bias-corrected = theta - bias = 2 theta - mean(thetas)
-    return 2 * theta - np.mean(thetas, axis=0)
+    return fn(sample) - bias(fn, sample, **kwargs)
 
 
 def variance(fn: Callable, sample: Sequence, **kwargs) -> np.ndarray:

--- a/resample/bootstrap.py
+++ b/resample/bootstrap.py
@@ -250,7 +250,7 @@ def variance(fn: Callable, sample: Sequence, **kwds) -> np.ndarray:
     ndarray
         Bootstrap estimate of variance.
     """
-    thetas = bootstrap(fn, sample, **kwds)
+    thetas = bootstrap(fn, sample, **kwargs)
     return np.var(thetas, ddof=1, axis=0)
 
 

--- a/resample/bootstrap.py
+++ b/resample/bootstrap.py
@@ -173,7 +173,7 @@ def confidence_interval(
     )
 
 
-def bias(fn: Callable, sample: Sequence, **kwds) -> np.ndarray:
+def bias(fn: Callable, sample: Sequence, **kwargs) -> np.ndarray:
     """
     Calculate bias of the function estimate with the bootstrap.
 

--- a/resample/bootstrap.py
+++ b/resample/bootstrap.py
@@ -183,7 +183,7 @@ def bias(fn: Callable, sample: Sequence, **kwds) -> np.ndarray:
         Function to be bootstrapped.
     sample : array-like
         Original sample.
-    **kwds
+    **kwargs
         Keyword arguments forwarded to :func:`resample`.
 
     Notes

--- a/resample/bootstrap.py
+++ b/resample/bootstrap.py
@@ -225,7 +225,7 @@ def bias_corrected(fn: Callable, sample: Sequence, **kwds) -> np.ndarray:
     """
 
     theta = fn(sample)
-    thetas = bootstrap(fn, sample, **kwds)
+    thetas = bootstrap(fn, sample, **kwargs)
     # bias = mean(thetas) - theta
     # bias-corrected = theta - bias = 2 theta - mean(thetas)
     return 2 * theta - np.mean(thetas, axis=0)

--- a/resample/bootstrap.py
+++ b/resample/bootstrap.py
@@ -204,7 +204,7 @@ def bias(fn: Callable, sample: Sequence, **kwds) -> np.ndarray:
     return np.mean(thetas, axis=0) - theta
 
 
-def bias_corrected(fn: Callable, sample: Sequence, **kwds) -> np.ndarray:
+def bias_corrected(fn: Callable, sample: Sequence, **kwargs) -> np.ndarray:
     """
     Calculate bias-corrected estimate of the function with the bootstrap.
 

--- a/resample/bootstrap.py
+++ b/resample/bootstrap.py
@@ -242,7 +242,7 @@ def variance(fn: Callable, sample: Sequence, **kwds) -> np.ndarray:
         and k is the length of the output array.
     sample : array-like
         Original sample.
-    **kwds
+    **kwargs
         Keyword arguments forwarded to :func:`resample`.
 
     Returns

--- a/resample/bootstrap.py
+++ b/resample/bootstrap.py
@@ -200,7 +200,7 @@ def bias(fn: Callable, sample: Sequence, **kwds) -> np.ndarray:
         Bootstrap estimate of bias (= expectation of estimator - true value).
     """
     theta = fn(sample)
-    thetas = bootstrap(fn, sample, **kwds)
+    thetas = bootstrap(fn, sample, **kwargs)
     return np.mean(thetas, axis=0) - theta
 
 

--- a/resample/bootstrap.py
+++ b/resample/bootstrap.py
@@ -231,7 +231,7 @@ def bias_corrected(fn: Callable, sample: Sequence, **kwds) -> np.ndarray:
     return 2 * theta - np.mean(thetas, axis=0)
 
 
-def variance(fn: Callable, sample: Sequence, **kwds) -> np.ndarray:
+def variance(fn: Callable, sample: Sequence, **kwargs) -> np.ndarray:
     """
     Calculate bootstrap estimate of variance.
 

--- a/resample/bootstrap.py
+++ b/resample/bootstrap.py
@@ -233,7 +233,7 @@ def bias_corrected(fn: Callable, sample: Sequence, **kwds) -> np.ndarray:
 
 def variance(fn: Callable, sample: Sequence, **kwds) -> np.ndarray:
     """
-    Calculate bootstrap estimate of estimator variance.
+    Calculate bootstrap estimate of variance.
 
     Parameters
     ----------

--- a/resample/bootstrap.py
+++ b/resample/bootstrap.py
@@ -215,7 +215,7 @@ def bias_corrected(fn: Callable, sample: Sequence, **kwds) -> np.ndarray:
         and k is the length of the output array.
     sample : array-like
         Original sample.
-    **kwds
+    **kwargs
         Keyword arguments forwarded to :func:`resample`.
 
     Returns

--- a/resample/bootstrap.py
+++ b/resample/bootstrap.py
@@ -206,7 +206,7 @@ def bias(fn: Callable, sample: Sequence, **kwds) -> np.ndarray:
 
 def bias_corrected(fn: Callable, sample: Sequence, **kwds) -> np.ndarray:
     """
-    Calculates bias-corrected estimate of the function with the bootstrap.
+    Calculate bias-corrected estimate of the function with the bootstrap.
 
     Parameters
     ----------

--- a/resample/tests/test_bootstrap.py
+++ b/resample/tests/test_bootstrap.py
@@ -266,7 +266,7 @@ def test_bias_on_biased_2(method, rng):
 
     r = bias(biased, data, method=method, size=10000, random_state=rng)
     sample_bias = bad - correct
-    assert r == pytest.approx(true_bias, rel=0.1)
+    assert r == pytest.approx(sample_bias, rel=0.1)
 
 
 @pytest.mark.parametrize("method", ("ordinary", "balanced"))

--- a/resample/tests/test_bootstrap.py
+++ b/resample/tests/test_bootstrap.py
@@ -265,7 +265,7 @@ def test_bias_on_biased_2(method, rng):
     correct = np.mean(data)
 
     r = bias(biased, data, method=method, size=10000, random_state=rng)
-    true_bias = bad - correct
+    sample_bias = bad - correct
     assert r == pytest.approx(true_bias, rel=0.1)
 
 

--- a/resample/tests/test_bootstrap.py
+++ b/resample/tests/test_bootstrap.py
@@ -251,6 +251,21 @@ def test_bias_on_biased(method, rng):
 
     r = bias(biased, data, method=method, size=10000, random_state=rng)
     true_bias = bad - correct
+    assert r == pytest.approx(true_bias, rel=0.05)
+
+
+@pytest.mark.parametrize("method", ("ordinary", "balanced"))
+def test_bias_on_biased_2(method, rng):
+    def biased(x):
+        n = len(x)
+        return (np.sum(x) + 2) / n
+
+    data = np.arange(100)
+    bad = biased(data)
+    correct = np.mean(data)
+
+    r = bias(biased, data, method=method, size=10000, random_state=rng)
+    true_bias = bad - correct
     assert r == pytest.approx(true_bias, rel=0.1)
 
 

--- a/resample/tests/test_bootstrap.py
+++ b/resample/tests/test_bootstrap.py
@@ -251,7 +251,7 @@ def test_bias_on_biased(method, rng):
 
     r = bias(biased, data, method=method, size=10000, random_state=rng)
     sample_bias = bad - correct
-    assert r == pytest.approx(true_bias, rel=0.05)
+    assert r == pytest.approx(sample_bias, rel=0.05)
 
 
 @pytest.mark.parametrize("method", ("ordinary", "balanced"))

--- a/resample/tests/test_bootstrap.py
+++ b/resample/tests/test_bootstrap.py
@@ -8,6 +8,9 @@ from resample.bootstrap import (
     bootstrap,
     confidence_interval,
     _fit_parametric_family,
+    bias,
+    bias_corrected,
+    variance,
 )
 
 PARAMETRIC_CONTINUOUS = {
@@ -222,3 +225,51 @@ def test_confidence_interval_invalid_ci_method_raises():
     msg = "method must be 'percentile', 'student', or 'bca'"
     with pytest.raises(ValueError, match=msg):
         confidence_interval(np.mean, (1, 2, 3), ci_method="foobar")
+
+
+@pytest.mark.parametrize("method", ("ordinary", "balanced"))
+def test_bias_on_unbiased(method, rng):
+    data = (0, 1, 2, 3)
+    r = bias(np.mean, data, method="balanced", random_state=rng)
+
+    if method == "balanced":
+        # bias is exactly zero for linear functions with the balanced bootstrap
+        assert r == 0
+    else:
+        # bias is not exactly zero for ordinary bootstrap
+        assert r == pytest.approx(0)
+
+
+@pytest.mark.parametrize("method", ("ordinary", "balanced"))
+def test_bias_on_biased(method, rng):
+    def biased(x):
+        return np.var(x, ddof=0)
+
+    data = np.arange(100)
+    bad = biased(data)
+    correct = np.var(data, ddof=1)
+
+    r = bias(biased, data, method=method, size=10000, random_state=rng)
+    true_bias = bad - correct
+    assert r == pytest.approx(true_bias, rel=0.1)
+
+
+@pytest.mark.parametrize("method", ("ordinary", "balanced"))
+def test_bias_corrected(method, rng):
+    def fn(x):
+        return np.var(x, ddof=0)
+
+    data = np.arange(100)
+    correct = np.var(data, ddof=1)
+
+    r = bias_corrected(fn, data, size=10000, method=method, random_state=rng)
+    assert r == pytest.approx(correct, rel=0.001)
+
+
+@pytest.mark.parametrize("method", ("ordinary", "balanced"))
+def test_variance(method, rng):
+    data = np.arange(100)
+    v = np.var(data) / len(data)
+
+    r = variance(np.mean, data, size=1000, method=method, random_state=rng)
+    assert r == pytest.approx(v, rel=0.05)

--- a/resample/tests/test_bootstrap.py
+++ b/resample/tests/test_bootstrap.py
@@ -250,7 +250,7 @@ def test_bias_on_biased(method, rng):
     correct = np.var(data, ddof=1)
 
     r = bias(biased, data, method=method, size=10000, random_state=rng)
-    true_bias = bad - correct
+    sample_bias = bad - correct
     assert r == pytest.approx(true_bias, rel=0.05)
 
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ def open_local(fn):
     this_directory = path.abspath(path.dirname(__file__))
     return open(path.join(this_directory, fn), encoding="utf-8")
 
-
 with open_local("README.md") as f:
     long_description = f.read()
 
@@ -27,4 +26,5 @@ setup(
     license="BSD-3-Clause",
     install_requires=requirements,
     zip_safe=False,
+    packages=["resample"]
 )


### PR DESCRIPTION
I added a warning to the bias computation with the bootstrap. Wording should be further improved for clarity.

I discovered that the bootstrap cannot detect biases of the kind (unbiased estimate + constant / N), where N is the number of observations, which the jackknife does detect and remove exactly. @dsaxton You can see it for yourself if you apply the bootstrap bias computation on the test function `def bad_mean(x): return (np.sum(x) + 2) / len(x)` that I used to test the jackknife. The bootstrap bias considers this function unbiased.

Somehow the meaning of the two bias computations is different. The jackknife computes the bias of the estimator on the finite sample with respect to the asymptotic limit. The bootstrap bias seems to compute something different.