### PR TITLE
Add Read the Docs YAML

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,13 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  version: 3.7
+  install:
+    - requirements: requirements.txt


### PR DESCRIPTION
Closes https://github.com/dsaxton/resample/issues/37

I'm not 100% positive this will work, but it seems it should prevent it from using Python 2 for the build.

https://docs.readthedocs.io/en/stable/config-file/v2.html