### PR TITLE
import submodules in `__init__.py`

### DIFF
--- a/resample/__init__.py
+++ b/resample/__init__.py
@@ -3,3 +3,7 @@ resample package.
 """
 
 from .version import version as __version__  # noqa
+from . import jackknife  # noqa
+from . import bootstrap  # noqa
+from . import empirical  # noqa
+from . import permutation  # noqa


### PR DESCRIPTION
This allows one to write
```
import resample

resample.jackknife.resample(...)
```
Without this, one can only do
```
from resample import jackknife
jackknife.resample(...)
```
I think it is common style to allow both uses, see e.g. numpy.