### PR TITLE
Rename higher-order functions

### DIFF
--- a/resample/__init__.py
+++ b/resample/__init__.py
@@ -2,8 +2,8 @@
 resample package.
 """
 
-from .version import version as __version__  # noqa
-from . import jackknife  # noqa
 from . import bootstrap  # noqa
 from . import empirical  # noqa
+from . import jackknife  # noqa
 from . import permutation  # noqa
+from .version import version as __version__  # noqa

--- a/resample/empirical.py
+++ b/resample/empirical.py
@@ -5,12 +5,14 @@ Empirical means they are based on the original data sample instead of a paramete
 density function.
 """
 from typing import Callable, Sequence
+
 import numpy as np
-from scipy.interpolate import interp1d as _interp1d
-from resample.jackknife import jackknife as _jackknife
+from scipy.interpolate import interp1d
+
+from resample.jackknife import jackknife
 
 
-def cdf_fn(sample: np.ndarray) -> Callable:
+def cdf_gen(sample: np.ndarray) -> Callable:
     """
     Return the empirical distribution function for the given sample.
 
@@ -29,9 +31,9 @@ def cdf_fn(sample: np.ndarray) -> Callable:
     return lambda x: np.searchsorted(sample, x, side="right", sorter=None) / n
 
 
-def quantile_fn(sample: np.ndarray) -> Callable:
+def quantile_function_gen(sample: np.ndarray) -> Callable:
     """
-    Return an empirical quantile function for the given sample.
+    Return the empirical quantile function for the given sample.
 
     Parameters
     ----------
@@ -53,7 +55,7 @@ def quantile_fn(sample: np.ndarray) -> Callable:
         if p < 1 / n:
             # TODO: How to handle this case?
             return sample[0]
-        return _interp1d(prob, sample)(p)
+        return interp1d(prob, sample)(p)
 
     return quant
 
@@ -77,4 +79,4 @@ def influence(fn: Callable, sample: Sequence) -> np.ndarray:
         Empirical influence values.
     """
     n = len(sample)
-    return (n - 1) * (fn(sample) - _jackknife(fn, sample))
+    return (n - 1) * (fn(sample) - jackknife(fn, sample))

--- a/resample/empirical.py
+++ b/resample/empirical.py
@@ -12,7 +12,7 @@ from scipy.interpolate import interp1d
 from resample.jackknife import jackknife
 
 
-def cdf_gen(sample: np.ndarray) -> Callable:
+def cdf_gen(sample: Sequence) -> Callable:
     """
     Return the empirical distribution function for the given sample.
 
@@ -31,7 +31,7 @@ def cdf_gen(sample: np.ndarray) -> Callable:
     return lambda x: np.searchsorted(sample, x, side="right", sorter=None) / n
 
 
-def quantile_function_gen(sample: np.ndarray) -> Callable:
+def quantile_function_gen(sample: Sequence) -> Callable:
     """
     Return the empirical quantile function for the given sample.
 

--- a/resample/jackknife.py
+++ b/resample/jackknife.py
@@ -1,8 +1,8 @@
 """
 Jackknife resampling.
 """
+from typing import Callable, Generator, Sequence
 
-from typing import Callable, Sequence, Generator
 import numpy as np
 
 

--- a/resample/permutation.py
+++ b/resample/permutation.py
@@ -1,9 +1,9 @@
 from typing import Dict, List
 
 import numpy as np
-from scipy.stats import rankdata as _rankdata
+from scipy.stats import rankdata
 
-from resample.empirical import cdf_fn as _cdf_fn
+from resample.empirical import cdf_gen
 
 
 def ttest(a1: np.ndarray, a2: np.ndarray, b: int = 100, random_state=None) -> Dict:
@@ -152,7 +152,7 @@ def wilcoxon(a1: np.ndarray, a2: np.ndarray, b: int = 100, random_state=None) ->
     n2 = len(a2)
 
     a = np.append(a1, a2)
-    a = _rankdata(a)
+    a = rankdata(a)
 
     X = np.apply_along_axis(
         func1d=np.random.permutation,
@@ -197,7 +197,7 @@ def kruskal_wallis(args: List[np.ndarray], b: int = 100, random_state=None) -> D
     ns = [len(a) for a in args]
     n = np.sum(ns)
     pos = np.append(0, np.cumsum(ns))
-    r_arr = _rankdata(np.concatenate(args))
+    r_arr = rankdata(np.concatenate(args))
     ri_means = [np.mean(r_arr[pos[i] : pos[i + 1]]) for i in range(t)]  # noqa: E203
     r_mean = np.mean(r_arr)
 
@@ -273,7 +273,7 @@ def corr_test(
     if method in ["pearson", "distance"]:
         X = np.asarray([a] * b)
     elif method == "spearman":
-        a = np.apply_along_axis(func1d=_rankdata, arr=a, axis=0)
+        a = np.apply_along_axis(func1d=rankdata, arr=a, axis=0)
         X = np.asarray([a] * b)
     else:
         raise ValueError(
@@ -328,8 +328,8 @@ def ks_test(a1: np.ndarray, a2: np.ndarray, b: int = 100, random_state=None) -> 
     n2 = len(a2)
     n = n1 + n2
 
-    f1 = _cdf_fn(a1)
-    f2 = _cdf_fn(a2)
+    f1 = cdf_gen(a1)
+    f2 = cdf_gen(a2)
     a = np.sort(np.append(a1, a2))
     d = np.max([abs(f1(v) - f2(v)) for v in a])
 

--- a/resample/tests/test_bootstrap.py
+++ b/resample/tests/test_bootstrap.py
@@ -1,15 +1,15 @@
 import numpy as np
-from numpy.testing import assert_equal, assert_almost_equal
+from numpy.testing import assert_almost_equal, assert_equal
 import pytest
 from scipy import stats
 
 from resample.bootstrap import (
-    resample,
-    bootstrap,
-    confidence_interval,
     _fit_parametric_family,
     bias,
     bias_corrected,
+    bootstrap,
+    confidence_interval,
+    resample,
     variance,
 )
 

--- a/resample/tests/test_empirical.py
+++ b/resample/tests/test_empirical.py
@@ -1,24 +1,24 @@
-import pytest
 import numpy as np
+import pytest
 
-from resample.empirical import quantile_fn, cdf_fn, influence
+from resample.empirical import cdf_gen, influence, quantile_function_gen
 
 
 def test_cdf_increasing():
     x = np.random.randn(100)
-    cdf = cdf_fn(x)
+    cdf = cdf_gen(x)
     result = [cdf(s) for s in np.linspace(x.min(), x.max(), 100)]
     assert np.all(np.diff(result) >= 0)
 
 
 def test_cdf_at_infinity():
-    cdf = cdf_fn(np.arange(10))
+    cdf = cdf_gen(np.arange(10))
     assert cdf(-np.inf) == 0.0
     assert cdf(np.inf) == 1.0
 
 
 def test_cdf_simple_cases():
-    cdf = cdf_fn([0, 1, 2, 3])
+    cdf = cdf_gen([0, 1, 2, 3])
     assert cdf(0) == 0.25
     assert cdf(1) == 0.5
     assert cdf(2) == 0.75
@@ -26,7 +26,7 @@ def test_cdf_simple_cases():
 
 
 def test_quantile_simple_cases():
-    q = quantile_fn([0, 1, 2, 3])
+    q = quantile_function_gen([0, 1, 2, 3])
     assert q(0.25) == 0
     assert q(0.5) == 1
     assert q(0.75) == 2
@@ -35,7 +35,7 @@ def test_quantile_simple_cases():
 
 @pytest.mark.parametrize("arg", [-1, 1.5])
 def test_quantile_out_of_bounds_raises(arg):
-    q = quantile_fn(np.array([0, 1, 2, 3]))
+    q = quantile_function_gen(np.array([0, 1, 2, 3]))
     msg = "Argument must be between zero and one"
     with pytest.raises(ValueError, match=msg):
         q(arg)

--- a/resample/tests/test_jackknife.py
+++ b/resample/tests/test_jackknife.py
@@ -2,13 +2,7 @@ import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal
 import pytest
 
-from resample.jackknife import (
-    resample,
-    jackknife,
-    bias,
-    bias_corrected,
-    variance,
-)
+from resample.jackknife import bias, bias_corrected, jackknife, resample, variance
 
 
 def test_resample_1d():


### PR DESCRIPTION
Closes https://github.com/dsaxton/resample/issues/31

While I don't think these names are great necessarily they're better than the `_fn` suffixes being used currently (I think `quantile_function_gen` is a slight improvement over `quantile_gen` since it makes it clear it's the quantile function that's being returned).

Also doing some other small cleaning (i.e., import sorting, removing what seem to be unnecessary underscore prefixes in imports; the functions aren't internal to the module and if they were I'd think the underscore should be part of the name). I'm actually surprised the CI wasn't failing due to formatting issues.