### PR TITLE
Change default size for bootstrap.resample

### DIFF
--- a/resample/bootstrap.py
+++ b/resample/bootstrap.py
@@ -119,7 +119,7 @@ def bootstrap(fn: Callable, sample: Sequence, **kwargs) -> np.ndarray:
     np.array
         Results of `fn` applied to each bootstrap sample.
     """
-    return np.asarray([fn(x) for x in resample(sample, size, **kwargs)])
+    return np.asarray([fn(x) for x in resample(sample, **kwargs)])
 
 
 def confidence_interval(

--- a/resample/bootstrap.py
+++ b/resample/bootstrap.py
@@ -12,7 +12,7 @@ from resample.jackknife import jackknife
 
 def resample(
     sample: Sequence,
-    size: int = 1000,
+    size: int = 100,
     method: str = "balanced",
     strata: Optional[Sequence] = None,
     random_state: Optional[Union[np.random.Generator, int]] = None,
@@ -101,7 +101,7 @@ def resample(
     return _resample_parametric(sample, size, dist, rng)
 
 
-def bootstrap(fn: Callable, sample: Sequence, size: int = 100, **kwargs) -> np.ndarray:
+def bootstrap(fn: Callable, sample: Sequence, **kwargs) -> np.ndarray:
     """
     Calculate function values from bootstrap samples.
 
@@ -111,8 +111,6 @@ def bootstrap(fn: Callable, sample: Sequence, size: int = 100, **kwargs) -> np.n
         Bootstrap samples are passed to this function.
     sample : array-like
         Original sample.
-    size : int
-        Number of bootstrap replicates.
     **kwargs
         Keywords are forwarded to :func:`resample`.
 

--- a/resample/bootstrap.py
+++ b/resample/bootstrap.py
@@ -111,6 +111,8 @@ def bootstrap(fn: Callable, sample: Sequence, size: int = 100, **kwargs) -> np.n
         Bootstrap samples are passed to this function.
     sample : array-like
         Original sample.
+    size : int
+        Number of bootstrap replicates.
     **kwargs
         Keywords are forwarded to :func:`resample`.
 


### PR DESCRIPTION
~Pretty straightforward fix here. Minor nitpicky detail: I'm calling the bootstrap samples _replicates_ however I noticed you call them _replicas_. In my experience the former is more common, but in any event I think it'd be good the use the same term consistently in the documentation so maybe we pick one.~

Closes https://github.com/dsaxton/resample/issues/51